### PR TITLE
Fix errors

### DIFF
--- a/Instructions/Labs/LAB_03_azure_compute.md
+++ b/Instructions/Labs/LAB_03_azure_compute.md
@@ -60,7 +60,7 @@ location='westus'
 adminUserName='azuser'
 adminPassword=!'UniqueP@$$w0rd-Here' # "!" を削除してください。そうしないと、エラーが発生します + 一意にしてください
 vmName='WestWinVM'
-vmSize='Standard_D1'
+vmSize='Standard_D2_v3'
 availabilitySet='WestAS'
 ```
 
@@ -169,6 +169,7 @@ Cloud Shell で 2 つの Debian 仮想サーバーを作成し、SSH を使用�
 ```sh
 az vm create \
 --image credativ:Debian:8:latest \
+--size 'Standard_D2_v3' \
 --admin-username azuser \
 --resource-group WestRG \
 --vnet-name WestVNet \
@@ -200,7 +201,7 @@ az vm availability-set create --name EastAS --resource-group EastRG
 ```sh
 az vm create \
 --image credativ:Debian:8:latest \
---size 'Standard_D1' \
+--size 'Standard_D2_v3' \
 --admin-username azuser \
 --resource-group EastRG \
 --vnet-name EastVNet \
@@ -403,6 +404,7 @@ ssh azuser@<instance 0 IP> -p 50000
 1. SSH セッションで次のコマンドを入力して、ストレス アプリケーションをインストールします (240 秒でタイムアウト)
 
 ```sh
+sudo apt-get update
 sudo apt-get -y install stress
 sudo stress --cpu 10 --timeout 240 &
 ```

--- a/Instructions/Labs/LAB_04_storage.md
+++ b/Instructions/Labs/LAB_04_storage.md
@@ -88,7 +88,7 @@ az storage account create \
     --kind $my_storage_kind \
     --access-tier $my_access_tier \
     --sku $my_storage_sku \
-    --encryption $my_storage_encryption
+    --encryption-services $my_storage_encryption
 ```
 
 **Bash CLI で環境変数を設定する**
@@ -208,7 +208,7 @@ touch uploadfiles/myfile.txt
 
 ```sh
 # REPLACE <name>
-az_user_name=<name>
+az_user_name='<name>'
 ```
 
 4. アップロード パスとフォルダを作成する
@@ -594,7 +594,7 @@ az storage account update -n $my_storage_account --https-only true
 
 ```sh
 # eastDebianVM SSH から
-cd /mnt/$my_storage_account
+cd /mnt/eastfiles
 ```
 
 3. Azure File Storage から VM に共有されているファイルを表示する


### PR DESCRIPTION
﻿# モジュール: 03
このプル要求で提案された変更:
 仮想マシンの作成時にサイズがD1ではエラーになるためすべてD2_v3で作成するように変更
 sudo apt-get -y install stressでエラーが発生するためsudo apt-get updateを追加


﻿# モジュール: 04
このプル要求で提案された変更:
 az storage account create コマンドの引数を現行CLIバージョンに合わせて変更
 ポータルで表示されるFilesの接続文字列が更新されて Linuxでマウントした際のディレクトリ名が変更されたため、それに合わせて修正
